### PR TITLE
부산대 FE_한재안 Step2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
             cd /react-deploy &&
             git pull origin gh-pages &&
             docker build -t my-react-app-nginx . &&
-            docker stop my-react-app || true &&
-            docker rm my-react-app || true &&
+            docker stop my-react-app &&
+            docker rm my-react-app &&
             docker run --name my-react-app -d -p 80:80 my-react-app-nginx
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: deploy
 on:
   push:
     branches:
-      - step1
+      - step2
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,9 +54,9 @@ jobs:
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
+          username: ec2-user
           script: |
-            cd /react-deploy &&
+            cd /home/ec2-user/react-deploy &&
             git pull origin gh-pages &&
             docker build -t my-react-app-nginx . &&
             docker stop my-react-app &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,18 +50,16 @@ jobs:
         run: sleep 30s
 
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.5.3
+        uses: appleboy/ssh-action@v1.0.3
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Deploy to EC2
-        run: |
-          ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} "
-          cd /react-deploy &&
-          git pull origin gh-pages &&
-          docker build -t my-react-app-nginx . &&
-          docker stop my-react-app || true &&
-          docker rm my-react-app || true &&
-          docker run --name my-react-app -d -p 80:80 my-react-app-nginx
-          "
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          script: |
+            cd /react-deploy &&
+            git pull origin gh-pages &&
+            docker build -t my-react-app-nginx . &&
+            docker stop my-react-app || true &&
+            docker rm my-react-app || true &&
+            docker run --name my-react-app -d -p 80:80 my-react-app-nginx
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,3 +46,22 @@ jobs:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: ./build
           publish_branch: gh-pages
+      - name: Wait for Deployment
+        run: sleep 30s
+
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Deploy to EC2
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} "
+          cd /react-deploy &&
+          git pull origin gh-pages &&
+          docker build -t my-react-app-nginx . &&
+          docker stop my-react-app || true &&
+          docker rm my-react-app || true &&
+          docker run --name my-react-app -d -p 80:80 my-react-app-nginx
+          "
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Install Dependencies
         run: npm i
 
+      - name: Create .env file
+        run: |
+          echo REACT_APP_BACKEND_URL_KIM_TAEYUN=${{ secrets.REACT_APP_BACKEND_URL_KIM_TAEYUN }} > .env
+          echo REACT_APP_BACKEND_URL_KANG_SUMIN=${{ secrets.REACT_APP_BACKEND_URL_KANG_SUMIN }} >> .env
+          echo REACT_APP_BACKEND_URL_YOO_KYUNGMI=${{ secrets.REACT_APP_BACKEND_URL_YOO_KYUNGMI }} >> .env
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           script: |

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -21,7 +21,6 @@ export const LoginPage = () => {
   const onNavigationButtonClick = () => setIsEnrollButtonClicked(!isEnrollButtonClicked);
 
   const handleConfirm = () => {
-    // TODO: API 연동 전까지 임시 로그인 처리
     authSessionStorage.set(email);
 
     const redirectUrl = queryParams.get('redirect') ?? `${process.env.PUBLIC_URL}/`;


### PR DESCRIPTION
안녕하세요 멘토님! 
저희 팀원별 배포 방식(http, https)이 다름이 따라, 모두 붙이고자 http, https 모두 배포해 붙이고 싶어 두 번 배포했습니다.
깃허브 페이지(https)를 통한 배포는 CI/CD까지 순탄하게 진행했으나, AWS(http)를 이용했을 때 어려움을 겪었습니다...
물론 특별한 실행 환경이 필요 없는 리액트 프로젝트에 도커 컨테이너 환경을 적용한 이유는 이번에 한 번 써보고 싶다는 마음이었습니다.

저는 프리티어를 사용했고, t2.micro 인스턴스에 Amazon Linux Image(Amazon Linux 2023)를 사용했습니다.
도커를 깔고, nginx 이미지 위에 `gh-pages` 브랜치를 클론 받아 build후 80번 포트에 붙이기만 했습니다.
별거 없지만 쉽지 않았습니다 ㅠㅠ. 
브랜치 받아서 `npm install` 했는데 인스턴스 응답 없어지고..  
`npm run buil` 한시간 r기다려도 안끝나서 그냥 인스턴스 종료하고.. 
도커를 다운 받으려고 Amazon Linux Image는 공식 문서에 없길래, RHEL 처럼하면 된다고 해서 설치 url 복사 붙여넣기 했는데 404나오고.. 
알고보니 더 이상 지원하지 않는 방법이고.. 
docker, nginx 사실 다 처음 써보고..
여러모로 쉽지 않았습니다.🥲

`gh-pages` 브랜치가 변경될 때, 해당 인스턴스 또한 풀을 받게 해 CI/CD 또한 구현 했습니다.
코드는 잘 돌아가는 것 같은데, 해당 인스턴스에 요청을 보내면 파일도 잘 받아오는데,
흰색 빈 화면이 뜹니다.. 되게 많은 시도했지만, 쉽지 않은 것 같습니다.
`[locatorjs]: Unsupported React renderer, only bundle type 1 (development) is supported but 0 (production) is found` 
이런 에러가 뜨긴 하지만, locatorjs는 크롬 확장 프로그램이기 때문에 흰 화면이 뜨는 이유를 찾을 수 없었습니다..
우선 Step3와 4를 빨리 진행후 추가적으로 디버깅 하겠습니다!
아래는 배포된 페이지들입니다. 😀

[깃허브페이지](https://jaeanhan.github.io/react-deploy/) (유경미 쿠키만 https로 배포된 상태입니다!)
[EC2](http://3.107.76.136/) (파일 잘 받아오는데 흰 화면입니다..)